### PR TITLE
fix: replace the getClassName address with a relative path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ export default ({
             styleMapsForFileByName[filename].importedHelperIndentifier,
           ),
         ],
-        types.stringLiteral('@dr.pogodin/babel-plugin-react-css-modules/dist/browser/getClassName'),
+        types.stringLiteral(resolve(__dirname, './browser/getClassName')),
       ),
     );
 


### PR DESCRIPTION
When the repo is packaged in another repository, tools like pnpm will not find the repo.

Like this:

Package A is dependent on [babel-plugin-react-css-modules](https://github.com/birdofpreyru/babel-plugin-react-css-modules)

Project B is dependent A。

An error is thrown when use classNames：

Module not found: Error: Can't resolve '@dr.pogodin/babel-plugin-react-css-modules/dist/browser/getClassName' in project B。

