### PR TITLE
Added ESM module support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.13.1",
+  "version": "6.13.2",
   "dependencies": {
     "@babel/core": "^7.24.5",
     "@babel/plugin-syntax-jsx": "^7.24.1",

--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ export default ({
             styleMapsForFileByName[filename].importedHelperIndentifier,
           ),
         ],
-        types.stringLiteral('@dr.pogodin/babel-plugin-react-css-modules/dist/browser/getClassName'),
+        types.stringLiteral('@dr.pogodin/babel-plugin-react-css-modules/dist/browser/getClassName.js'),
       ),
     );
 


### PR DESCRIPTION
ESM modules (Node with `type: module`) require imports to have the .js file extension. For some reason the module crashes whenever babel tries to use load/use it.

Node 22.2.0 without the .js extension
```js
error: Cannot find module '/Users/david/git/white-room/node_modules/@dr.pogodin/babel-plugin-react-css-modules/dist/browser/getClassName' imported from /Users/david/git/white-room/src/client/components/Link/Link.jsx
Did you mean to import "@dr.pogodin/babel-plugin-react-css-modules/dist/browser/getClassName.js"? {"code":"ERR_MODULE_NOT_FOUND","stack":"Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/david/git/white-room/node_modules/@dr.pogodin/babel-plugin-react-css-modules/dist/browser/getClassName'
```
